### PR TITLE
Add Copyright headers (2)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Moritz Eysholdt - Initial contribution and API
+ *******************************************************************************/
+
 // tell Jenkins how to build projects from this repository
 node {
 	

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <!--
-Copyright (c) 2013-2017 TypeFox GmbH and itemis AG.
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!--
 Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
 All rights reserved. This program and the accompanying materials

--- a/org.eclipse.xtext.example.arithmetics.xpect.tests/fragment.xml
+++ b/org.eclipse.xtext.example.arithmetics.xpect.tests/fragment.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <?eclipse version="3.4"?>
 <fragment>
    <extension

--- a/org.eclipse.xtext.example.arithmetics.xpect.tests/pom.xml
+++ b/org.eclipse.xtext.example.arithmetics.xpect.tests/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.eclipse.xtext.example.domainmodel.xpect.tests/pom.xml
+++ b/org.eclipse.xtext.example.domainmodel.xpect.tests/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.doc/javadoc.xml
+++ b/org.xpect.doc/javadoc.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
 <project default="javadoc">
     <target name="javadoc">
         <javadoc access="public" classpath=".:${java.home}/../lib/tools.jar" packagenames="org.xpect.doc" sourcepath="src">

--- a/org.xpect.releng/component.def
+++ b/org.xpect.releng/component.def
@@ -1,2 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
 <targlets:ComponentDefinition xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:targlets="http://www.eclipse.org/oomph/targlets/1.0" id="org.xpect.releng"/>

--- a/org.xpect.releng/maven-plugin-parent/pom.xml
+++ b/org.xpect.releng/maven-plugin-parent/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/maven-test-parent/pom.xml
+++ b/org.xpect.releng/maven-test-parent/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/p2-repository/category.xml
+++ b/org.xpect.releng/p2-repository/category.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
 <site>
 	<feature url="features/org.xpect.sdk_0.2.0.qualifier.jar" id="org.xpect.sdk"
 		version="0.2.0.qualifier">

--- a/org.xpect.releng/p2-repository/pom.xml
+++ b/org.xpect.releng/p2-repository/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/target-platforms/eclipse_4_5_0-xtext_nightly/pom.xml
+++ b/org.xpect.releng/target-platforms/eclipse_4_5_0-xtext_nightly/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/target-platforms/eclipse_4_6_3-xtext_2_9_2/pom.xml
+++ b/org.xpect.releng/target-platforms/eclipse_4_6_3-xtext_2_9_2/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/xtext-examples/maven-parents/grammar-plugin/pom.xml
+++ b/org.xpect.releng/xtext-examples/maven-parents/grammar-plugin/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics.ide/pom.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics.ide/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics.tests/pom.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics.tests/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics.ui/plugin.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics.ui/plugin.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <?eclipse version="3.0"?>
 <plugin>
 	<extension

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics.ui/pom.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics.ui/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics/plugin.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics/plugin.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <?eclipse version="3.0"?>
 <plugin>
 	<extension point="org.eclipse.emf.ecore.generated_package">

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics/pom.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.tests/pom.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.tests/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.ui/plugin.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.ui/plugin.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.ui/pom.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.ui/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.ui/templates/templates.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.ui/templates/templates.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
 <templates>
     <template name="Package" description="template for a Package"
         id="org.eclipse.xtext.example.domainmodel.Domainmodel.PackageDeclaration"

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel/plugin.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel/plugin.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.0"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
 
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
+<?eclipse version="3.0"?>
 <plugin>
 
   <extension point="org.eclipse.emf.ecore.generated_package">

--- a/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel/pom.xml
+++ b/org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.sdk/feature.xml
+++ b/org.xpect.sdk/feature.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <feature
       id="org.xpect.sdk"
       label="Xpect SDK Feature "

--- a/org.xpect.sdk/pom.xml
+++ b/org.xpect.sdk/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.tests/pom.xml
+++ b/org.xpect.tests/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.ui.junit/plugin.xml
+++ b/org.xpect.ui.junit/plugin.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/org.xpect.ui.junit/pom.xml
+++ b/org.xpect.ui.junit/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.ui/plugin.xml
+++ b/org.xpect.ui/plugin.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/org.xpect.ui/pom.xml
+++ b/org.xpect.ui/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.xtext.lib.feature/feature.xml
+++ b/org.xpect.xtext.lib.feature/feature.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <feature
       id="org.xpect.xtext.lib.feature"
       label="Xpect Test Library Feature"

--- a/org.xpect.xtext.lib.feature/pom.xml
+++ b/org.xpect.xtext.lib.feature/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.xtext.lib.tests/plugin.xml
+++ b/org.xpect.xtext.lib.tests/plugin.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <?eclipse version="3.4"?>
 <plugin>
    <extension

--- a/org.xpect.xtext.lib.tests/pom.xml
+++ b/org.xpect.xtext.lib.tests/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.xtext.lib/pom.xml
+++ b/org.xpect.xtext.lib/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.xtext.xbase.lib.feature/feature.xml
+++ b/org.xpect.xtext.xbase.lib.feature/feature.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <feature
       id="org.xpect.xtext.xbase.lib.feature"
       label="Xpect Xbase Test Library Feature"

--- a/org.xpect.xtext.xbase.lib.feature/pom.xml
+++ b/org.xpect.xtext.xbase.lib.feature/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect.xtext.xbase.lib/pom.xml
+++ b/org.xpect.xtext.xbase.lib/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.xpect/plugin.xml
+++ b/org.xpect/plugin.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.0"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
 
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
+<?eclipse version="3.0"?>
 <plugin>
    <extension-point id="fileExtensions" name="fileExtensions" schema="schema/fileExtensions.exsd"/>
    <extension-point id="testSuite" name="testSuite" schema="schema/testSuite.exsd"/>

--- a/org.xpect/pom.xml
+++ b/org.xpect/pom.xml
@@ -1,3 +1,14 @@
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Moritz Eysholdt - Initial contribution and API
+-->
+
 <project
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">


### PR DESCRIPTION
## Results after commit ecbb948

```
Checked 895 files, including 0 third-party files
Valid files: 670
Invalid files: 225
Erroneous files: 0
=====================================================================================
Total number of files without copyright header in N4JS repository: 219
-- Number of files that canNOT have a copyright header: 213
   prefs                  :    63
   properties             :    27
   project                :    23
   gitignore              :    22
   MF                     :    18
   classpath              :    18
   gif                    :    14
   launch                 :     8
   xml_gen                :     5
   ecore                  :     4
   genmodel               :     3
   exsd                   :     2
   target                 :     2
   key                    :     1
   pdf                    :     1
   png                    :     1
   setup                  :     1
   -----------------------------------------------------------------
   Sum                    :   213

-- Number of files that can have a copyright header: 5
   html                   :     3
   dmodel                 :     2
   -----------------------------------------------------------------
   Sum                    :     5
```

**Especially mind the changes in the following files:**
* org.xpect.doc/doc-gen/index.html
* org.xpect.doc/javadoc.xml
* org.xpect.doc/src-doc/motivation.html
* org.xpect.releng/component.def
* org.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.ui/templates/templates.xml

**Question:**
Can copyright headers be added to: 
* org.eclipse.xtext.example.domainmodel.xpect.tests/src/org/eclipse/xtext/example/domainmodel/xpect/tests/linking/test2.dmodel
* org.eclipse.xtext.example.domainmodel.xpect.tests/src/org/eclipse/xtext/example/domainmodel/xpect/tests/parser/test2.dmodel